### PR TITLE
adds runloop selection

### DIFF
--- a/LVDebounce.h
+++ b/LVDebounce.h
@@ -10,6 +10,6 @@
 
 @interface LVDebounce : NSObject
 
-+ (void)fireAfter:(NSTimeInterval)seconds target:(id)target selector:(SEL)aSelector userInfo:(id)userInfo;
++ (void)fireAfter:(NSTimeInterval)seconds target:(id)target selector:(SEL)aSelector userInfo:(id)userInfo runLoop:(NSRunLoop *)runLoop;
 
 @end

--- a/LVDebounce.m
+++ b/LVDebounce.m
@@ -18,7 +18,7 @@ static NSMutableDictionary *timers = nil;
     }
 }
 
-+ (void)fireAfter:(NSTimeInterval)seconds target:(id)target selector:(SEL)aSelector userInfo:(id)userInfo {
++ (void)fireAfter:(NSTimeInterval)seconds target:(id)target selector:(SEL)aSelector userInfo:(id)userInfo runLoop:(NSRunLoop *)runLoop {
     @synchronized(self) {
         NSArray *eventKey = @[target, NSStringFromSelector(aSelector)];
         if ([timers objectForKey:eventKey]) {
@@ -30,8 +30,14 @@ static NSMutableDictionary *timers = nil;
             [timers removeObjectForKey:eventKey];
         }
 
-        [timers setObject:[NSTimer scheduledTimerWithTimeInterval:seconds target:target selector:aSelector userInfo:userInfo repeats:NO]
-                   forKey:eventKey];
+        if(!runLoop){
+            runLoop = [NSRunLoop currentRunLoop];
+        }
+
+        NSTimer *timer = [NSTimer timerWithTimeInterval:seconds target:target selector:aSelector userInfo:userInfo repeats:NO];
+        [runLoop addTimer:timer forMode:NSDefaultRunLoopMode];
+
+        [timers setObject:timer forKey:eventKey];
     }
 }
 


### PR DESCRIPTION
When using this in my NSDocument based application, I have the following defined for my NSDocument subclass:

``` objc
+ (BOOL)canConcurrentlyReadDocumentsOfType:(NSString *)typeName
```

This returns `YES` which is great for my needs, but while the document is loading I need to schedule some debouncing operations, also good, except the current implementation of `LVDebounce` always assumes the current RunLoop. Once the background loading of the NSDocument completes, the background thread performing the load will finish and the debounce action will never fire.

Allowing the RunLoop to be specifically defined solves this problem. In my loading setup, I just set the runloop in my call to LVDebounce to be `[NSRunLoop mainRunLoop]` and everything works as expected.

Again, if the runloop is not specified, the `currentRunLoop` is assumed.
